### PR TITLE
chore: bootstrap enforce-repo-settings workflow

### DIFF
--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -1,0 +1,29 @@
+---
+name: Enforce Repository Settings
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  push:
+    branches: [main]
+    paths:
+      - '.github/config/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: enforce-repo-settings
+  cancel-in-progress: true
+
+jobs:
+  enforce-settings:
+    uses: f5xc-salesdemos/docs-control/.github/workflows/enforce-repo-settings.yml@main
+    secrets:
+      repo-settings-token: ${{ secrets.REPO_SETTINGS_TOKEN }}
+
+  sync-files:
+    uses: f5xc-salesdemos/docs-control/.github/workflows/sync-managed-files.yml@main
+    secrets:
+      repo-sync-token: ${{ secrets.REPO_SYNC_TOKEN }}


### PR DESCRIPTION
## Summary

Add `enforce-repo-settings.yml` workflow to bootstrap managed file sync from docs-control.

## Problem

terraform-provider-mcp is listed in `docs-control/.github/config/downstream-repos.json` but has never received its managed files. The dispatch from docs-control runs `gh workflow run enforce-repo-settings.yml` in each downstream repo — but this repo didn't have that workflow file, so dispatches failed silently.

## Solution

Copy `enforce-repo-settings.yml` from docs-control's workflow templates. Once merged, the next dispatch from docs-control will successfully trigger the full sync and all 26 managed files will arrive via a governance PR.

## Post-merge steps

1. Manually dispatch: `gh workflow run enforce-repo-settings.yml --repo f5xc-salesdemos/terraform-provider-mcp`
2. Wait for sync PR with managed files
3. Verify CLAUDE.md arrives with Organization Overview

Closes #1